### PR TITLE
Roll back to langchain-core 0.1.4

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -4,6 +4,7 @@ dependencies:
   - pip
   - pip:
     - jupyterlab==4.0.9
+    - langchain-core==0.1.4
     - langchain-google-genai==0.0.5
     - langchain==0.0.352
     - python-dotenv==1.0.0


### PR DESCRIPTION
## Overview
This PR solves #10 by pinning the `langchain-core` package to version 0.1.4 (roll back) so that the scheduled publish workflow works.

`langchain-core` is a dependency of the Langchain package. A newer version was released recently so when Langchain is installed, `langchain-core 0.1.5` is automatically installed. As mentioned in [this issue](https://github.com/langchain-ai/langchain/issues/15491), it has a bug when referencing the `tracing_enabled` module.

## Changes
- Updated `conda.yml` to pin `langchain-core` to version 0.1.4